### PR TITLE
Python 3 support for Kodi 19 Matrix

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1,4 +1,4 @@
-from urlparse import parse_qsl
+from urllib.parse import parse_qsl
 from video import VideoHandler
 from audio import AudioHandler
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.eitb" name="EITB Nahieran (unofficial)" version="1.0.6" provider-name="Mikel Larreategi">
+<addon id="plugin.video.eitb" name="EITB Nahieran (unofficial)" version="2.0.0" provider-name="Mikel Larreategi">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.22.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.eitb" name="EITB Nahieran (unofficial)" version="1.0.5" provider-name="Mikel Larreategi">
+<addon id="plugin.video.eitb" name="EITB Nahieran (unofficial)" version="1.0.6" provider-name="Mikel Larreategi">
     <requires>
-        <import addon="xbmc.python" version="2.24.0"/>
-        <import addon="script.module.requests" version="2.9.1"/>
+        <import addon="xbmc.python" version="3.0.0"/>
+        <import addon="script.module.requests" version="2.22.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon.py">
         <provides>video audio</provides>

--- a/addon.xml
+++ b/addon.xml
@@ -19,5 +19,9 @@
         <source>https://github.com/erral/plugin.video.eitb</source>
         <website>https://github.com/erral/plugin.video.eitb</website>
         <email>larreategi@eibar.org</email>
+        <assets>
+            <icon>icon.png</icon>
+            <fanart>fanart.jpg</fanart>
+        </assets>
     </extension>
 </addon>


### PR DESCRIPTION
# Kodi 19 Matrix-erako euskarria. 
Oraindik ez dago presarik, oraingoz *"release candidate"* bat besterik ez baita.
- Artikulua: https://kodi.tv/article/kodi-19x-matrix-release-candidate
- GitHub: https://github.com/xbmc/xbmc/releases/tag/19.0RC1-Matrix

Hona hemen egindako aldaketak:
- [xbmc.python 3.0.0](https://kodi.wiki/view/Addon.xml) bertsiora eguneratu da.
![Pantaila-argazkia 2021-02-07 16-37-15](https://user-images.githubusercontent.com/26112509/107151442-e84cf080-6962-11eb-9b0f-a7c6aed819fa.png)
- script.module.requests 2.9.1 bertsiotik 2.22.0 bertsiora eguneratu da.
-  [urlparse python 3an](https://github.com/bipoza/plugin.video.eitb/commit/35bf4a5ecfe487e95aac20d6ceb3e851c0e32985#) erabiltzeko doitu da.
- *Semantic versioning* gidalerroei jarraituz, **2.0.0** bertsiora eguneratu da.
![Pantaila-argazkia 2021-02-07 17-57-34](https://user-images.githubusercontent.com/26112509/107153456-f9e7c580-696d-11eb-9ecf-1d2ba70a321e.png)

Oharrak:
- Aldaketa hauek ez dute funtzionatzen Kodi 18an (Python 2). Beraz, aldaketak onartu eta eguneratzen badira, bakarrik matrix bertsiorako egin beharko da. [Hemen adibide batzuk](https://github.com/xbmc/repo-plugins/pulls?q=is%3Apr+matrix+is%3Aclosed)

